### PR TITLE
Add a utils dir to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as md:
 
 setup(
     name="pyawx-client",
-    packages=["pyawx", "pyawx.models", "pyawx.exceptions"],
+    packages=["pyawx", "pyawx.models", "pyawx.models.utils", "pyawx.exceptions"],
     version=version,
     license="Apache 2.0",
     description="Python API to access Ansible AWX/Tower v2 API",


### PR DESCRIPTION
Hello! Thanks for your work!

I tried to work with your module installed from the PIP repository (https://pypi.org/project/pyawx-client/) and tried running the following code:

```
# Interaction with AWX via API: work with inventory, projects, templates, jobs, etc

import pyawx
import os

# Req ENVs:
# AWX_LOGIN=admin
# AWX_PASS=1242342
# AWX_HOST=http://127.0.0.1

def awxer_connecter():

    # Get user/password/host from envs
    awxLogin = os.getenv('AWX_LOGIN')
    awxPass = os.getenv('AWX_PASS')
    awxHost = os.getenv('AWX_HOST')

    # Try to connect to AWX
    client = pyawx.Client(awxHost, username=awxLogin, password=awxPass)

    return client

awxer_connecter()
``` 

Unfortunately I just got the following error:

```
Traceback (most recent call last):
  File "/home/piknik/git/mail/platform/ansible-openstack/./tools/testing/run.py", line 10, in <module>
    from awxer.awxer import awxer_connecter
  File "/home/piknik/git/mail/platform/ansible-openstack/tools/testing/awxer/awxer.py", line 4, in <module>
    import pyawx
  File "/home/piknik/.local/lib/python3.9/site-packages/pyawx/__init__.py", line 7, in <module>
    from pyawx.api import Client
  File "/home/piknik/.local/lib/python3.9/site-packages/pyawx/api.py", line 4, in <module>
    from pyawx.models.utils import get_endpoint, update, flush
ModuleNotFoundError: No module named 'pyawx.models.utils'
```

Then I found that the Utils directory simply didn't exist it into the PIP package - it's in the repository, but not in the PIP package.

```
$ ls /home/piknik/.local/lib/python3.9/site-packages/pyawx/models/
adhoc.py         credentials.py  instances.py    jobs.py    _mixins.py  notifications.py  projects.py  types.py    users.py  workflows.py
applications.py  __init__.py     inventories.py  labels.py  mixins.py   organizations.py  __pycache__  unified.py 
```

Apparently it just forgot to be added there. I have added the missing directory and hope it helps